### PR TITLE
Updated Glidex.Forms Initialization

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -34,7 +34,7 @@ LoadApplication(new ImageSourceHandlers.Forms.Sample.Views.App());
 ```csharp
 Xamarin.Forms.Forms.Init (this, bundle);
 //This forces the custom renderers to be used
-Android.Glide.Forms.Init ();
+Android.Glide.Forms.Init (this);
 LoadApplication (new App ());
 ```
 


### PR DESCRIPTION
The new way to initialize Glidex.Forms is to pass in the `Activity`: `Android.Glide.Forms.Init(this)`

`Android.Glide.Forms.Init()` has been marked obsolete.

<img width="623" alt="image" src="https://user-images.githubusercontent.com/13558917/76654521-5c4f0080-6528-11ea-810c-8c828c6e0933.png">